### PR TITLE
Added API layer 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -93,3 +93,4 @@ iOSInjectionProject/
 
 # misc
 .DS_Store
+xcshareddata

--- a/Sources/SpaceXAPI/Api.swift
+++ b/Sources/SpaceXAPI/Api.swift
@@ -1,0 +1,112 @@
+import Foundation
+
+final public class Api {
+    private let baseURL = URL(string: "https://api.spacexdata.com/v3")!
+    private let urlSession: NetworkSession
+    private var sessionTask: URLSessionTask?
+
+    public init(urlSession: NetworkSession) {
+        self.urlSession = urlSession
+    }
+}
+
+extension Api {
+    func get<Model: Codable>(endpoint: Endpoint, completion: @escaping (Result<Model, Error>) -> Void) {
+        sessionTask = get(endpoint) { (result) in
+            do {
+
+                let data = try result.get()
+                let decoder = JSONDecoder(dateDecodingStrategy: .secondsSince1970)
+                let model = try decoder.decoded(Model.self, from: data)
+
+                completion(.success(model))
+
+            } catch {
+                completion(.failure(error))
+
+            }
+        }
+    }
+
+    func cancelCurrentSession() {
+        sessionTask?.cancel()
+    }
+}
+
+private extension Api {
+    private func get(_ endpoint: Endpoint,
+                     options: Options? = nil,
+                     completion: @escaping (Result<Data, Error>) -> Void) -> URLSessionTask {
+
+        let url = buildURL(for: endpoint, using: options)
+
+        let sessionTask = urlSession.dataTask(with: url) { data, urlResponse, error in
+            if let error = error {
+                completion(Result.failure(error))
+                return
+            }
+
+            guard let httpResponse = urlResponse as? HTTPURLResponse else {
+                completion(Result.failure(SpaceXAPIError.unknownResponse))
+                return
+            }
+
+            guard (200 ..< 300).contains(httpResponse.statusCode) else {
+                completion(Result.failure(SpaceXAPIError.serverReturnedCode(httpResponse.statusCode)))
+                return
+            }
+
+            guard let data = data else {
+                completion(Result.failure(SpaceXAPIError.emptyResponse))
+                return
+            }
+
+            completion(Result.success(data))
+        }
+        
+        return sessionTask
+    }
+
+    private func buildURL(for endpoint: Endpoint, using options: Options?) -> URL {
+        let url = baseURL.appendingPathComponent(endpoint.path)
+
+        guard let options = options else { return url }
+
+        var components = URLComponents(url: url, resolvingAgainstBaseURL: false)
+        components?.queryItems = options.queryItems
+
+        return components?.url ?? url
+    }
+}
+
+fileprivate struct Options {
+    public var queryItems: [URLQueryItem] {
+        var parameters: [String: String] = [:]
+
+        if let options = filterOptions {
+            parameters["filter"] = options.joined(separator: ",")
+        }
+
+        parameters["limit"] = String(limit)
+        parameters["offset"] = String(offset)
+
+        return parameters.map { URLQueryItem(name: $0, value: $1) }
+    }
+
+    private let filterOptions: [String]?
+    private let limit: Int
+    private let offset: Int
+
+    /// Create result query options
+    ///
+    /// - Parameters:
+    ///   - filterOptions: An optional array of query fields. If this is set then only these values will be returned
+    ///   by the API. For example, specifying `flight_number` will only return `flight_number` values from the API.
+    ///   - limit: Page limit to be returned, defaults to `25`
+    ///   - offset: Page offset, defaults to `0`
+    public init(filterOptions: [String]? = nil, limit: Int = 25, offset: Int = 0) {
+        self.filterOptions = filterOptions
+        self.limit = limit
+        self.offset = offset
+    }
+}

--- a/Sources/SpaceXAPI/Api.swift
+++ b/Sources/SpaceXAPI/Api.swift
@@ -1,7 +1,7 @@
 import Foundation
 
 final public class Api {
-    private let baseURL = URL(string: "https://api.spacexdata.com/v3")!
+    private let baseURL = URL(string: "https://api.spacexdata.com/v4")!
     private let urlSession: NetworkSession
     private var sessionTask: URLSessionTask?
 

--- a/Sources/SpaceXAPI/Api.swift
+++ b/Sources/SpaceXAPI/Api.swift
@@ -11,7 +11,7 @@ final public class Api {
 }
 
 extension Api {
-    func get<Model: Codable>(endpoint: Endpoint, completion: @escaping (Result<Model, Error>) -> Void) {
+    public func get<Model: Codable>(endpoint: Endpoint, completion: @escaping (Result<Model, Error>) -> Void) {
         sessionTask = get(endpoint) { (result) in
             do {
 

--- a/Sources/SpaceXAPI/Api.swift
+++ b/Sources/SpaceXAPI/Api.swift
@@ -1,7 +1,6 @@
 import Foundation
 
 final public class Api {
-    private let baseURL = URL(string: "https://api.spacexdata.com/v4")!
     private let urlSession: NetworkSession
     private var sessionTask: URLSessionTask?
 
@@ -68,7 +67,7 @@ private extension Api {
     }
 
     private func buildURL(for endpoint: Endpoint, using options: Options?) -> URL {
-        let url = baseURL.appendingPathComponent(endpoint.path)
+        let url = endpoint.url.appendingPathComponent(endpoint.path)
 
         guard let options = options else { return url }
 

--- a/Sources/SpaceXAPI/Codable+Extensions.swift
+++ b/Sources/SpaceXAPI/Codable+Extensions.swift
@@ -1,0 +1,21 @@
+import Foundation
+
+protocol AnyDecoder {
+    func decoded<T: Decodable>(_ type: T.Type, from data: Data)throws -> T
+}
+
+extension JSONDecoder: AnyDecoder {
+    func decoded<T>(_ type: T.Type, from data: Data) throws -> T where T: Decodable {
+        return try decode(type, from: data)
+    }
+}
+
+protocol AnyEncoder {
+    func encode<T: Encodable>(_ value: T) throws -> Data
+}
+
+extension JSONEncoder: AnyEncoder {
+    func encode<T>(_ value: T) throws -> Data where T: Encodable {
+        return try encode(value)
+    }
+}

--- a/Sources/SpaceXAPI/Endpoints.swift
+++ b/Sources/SpaceXAPI/Endpoints.swift
@@ -28,38 +28,38 @@ public extension Endpoint {
 extension Endpoint {
     /// Returns an array of All Launches
     /// - Note: https://github.com/r-spacex/SpaceX-API/blob/master/docs/v4/launches/all.md
-    static var allLaunches: Self {
+    public static var allLaunches: Self {
         Endpoint(path: "launches")
     }
 
     /// Returns an array of Past Launches
     /// - Note: https://github.com/r-spacex/SpaceX-API/blob/master/docs/v4/launches/past.md
-    static var pastLaunches: Self {
+    public static var pastLaunches: Self {
         Endpoint(path: "launches/past")
     }
 
     /// Returns an array of Upcoming Launches
     /// - Note: https://github.com/r-spacex/SpaceX-API/blob/master/docs/v4/launches/upcoming.md
-    static var upcomingLaunches: Self {
+    public static var upcomingLaunches: Self {
         Endpoint(path: "launches/upcoming")
     }
 
     /// Returns an array of Latest Launches
     /// - Note: https://github.com/r-spacex/SpaceX-API/blob/master/docs/v4/launches/latest.md
-    static var latestLaunches: Self {
+    public static var latestLaunches: Self {
         Endpoint(path: "launches/latest")
     }
 
     /// Returns an array of Next Launches
     /// - Note: https://github.com/r-spacex/SpaceX-API/blob/master/docs/v4/launches/next.md
-    static var nextLaunches: Self {
+    public static var nextLaunches: Self {
         Endpoint(path: "launches/next")
     }
 
     /// Returns a single Launch
     /// - Note: https://github.com/r-spacex/SpaceX-API/blob/master/docs/v4/launches/one.md
     /// - Parameter id: ID of the Launch  to get
-    static func launch(withId id: String) -> Self {
+    public static func launch(withId id: String) -> Self {
         Endpoint(path: "launches/\(id)")
     }
 }
@@ -68,14 +68,14 @@ extension Endpoint {
 extension Endpoint {
     /// Returns an array of Capsules
     /// - Note: https://github.com/r-spacex/SpaceX-API/blob/master/docs/v4/capsules/all.md
-    static var allCapsules: Self {
+    public static var allCapsules: Self {
         Endpoint(path: "capsules")
     }
 
     /// Returns a single Capsule
     /// - Note: https://github.com/r-spacex/SpaceX-API/blob/master/docs/v4/capsules/one.md
     /// - Parameter id: ID of the Capsule  to get
-    static func capsule(withId id: String) -> Self {
+    public static func capsule(withId id: String) -> Self {
         Endpoint(path: "capsules/\(id)")
     }
 }
@@ -85,7 +85,7 @@ extension Endpoint {
 
     /// Returns the company info in a single object
     /// - Note: https://github.com/r-spacex/SpaceX-API/blob/master/docs/v4/company/all.md
-    static var companyInfo: Self {
+    public static var companyInfo: Self {
         Endpoint(path: "company")
     }
 }
@@ -94,14 +94,14 @@ extension Endpoint {
 extension Endpoint {
     /// Returns an array of Cores
     /// - Note: https://github.com/r-spacex/SpaceX-API/blob/master/docs/v4/cores/all.md
-    static var allCores: Self {
+    public static var allCores: Self {
         Endpoint(path: "cores")
     }
 
     /// Returns a single Core
     /// - Note: https://github.com/r-spacex/SpaceX-API/blob/master/docs/v4/cores/one.md
     /// - Parameter id: ID of the core to get
-    static func core(withId id: String) -> Self {
+    public static func core(withId id: String) -> Self {
         Endpoint(path: "cores/\(id)")
     }
 }
@@ -110,14 +110,14 @@ extension Endpoint {
 extension Endpoint {
     /// Returns an array of Crew members
     /// - Note: https://github.com/r-spacex/SpaceX-API/blob/master/docs/v4/crew/all.md
-    static var allCrewMembers: Self {
+    public static var allCrewMembers: Self {
         Endpoint(path: "crew")
     }
 
     /// Returns a single Crew members
     /// - Note: https://github.com/r-spacex/SpaceX-API/blob/master/docs/v4/crew/one.md
     /// - Parameter id: ID of the crew member to get
-    static func crewMember(withId id: String) -> Self {
+    public static func crewMember(withId id: String) -> Self {
         Endpoint(path: "crew/\(id)")
     }
 }
@@ -126,14 +126,14 @@ extension Endpoint {
 extension Endpoint {
     /// Returns an array of Dragons
     /// - Note: https://github.com/r-spacex/SpaceX-API/blob/master/docs/v4/dragons/all.md
-    static var allDragons: Self {
+    public static var allDragons: Self {
         Endpoint(path: "dragons")
     }
 
     /// Returns a single Dragon
     /// - Note: https://github.com/r-spacex/SpaceX-API/blob/master/docs/v4/dragons/one.md
     /// - Parameter id: ID of the Dragon to get
-    static func dragon(withId id: String) -> Self {
+    public static func dragon(withId id: String) -> Self {
         Endpoint(path: "dragons/\(id)")
     }
 }
@@ -142,14 +142,14 @@ extension Endpoint {
 extension Endpoint {
     /// Returns an array of Landpads
     /// - Note: https://github.com/r-spacex/SpaceX-API/blob/master/docs/v4/landpads/all.md
-    static var allLandpads: Self {
+    public static var allLandpads: Self {
         Endpoint(path: "landpads")
     }
 
     /// Returns a single Landpad
     /// - Note: https://github.com/r-spacex/SpaceX-API/blob/master/docs/v4/landpads/one.md
     /// - Parameter id: ID of the Landpad to get
-    static func landpad(withId id: String) -> Self {
+    public static func landpad(withId id: String) -> Self {
         Endpoint(path: "landpads/\(id)")
     }
 }
@@ -158,14 +158,14 @@ extension Endpoint {
 extension Endpoint {
     /// Returns an array of Launchpads
     /// - Note: https://github.com/r-spacex/SpaceX-API/blob/master/docs/v4/launchpads/all.md
-    static var allLaunchpads: Self {
+    public static var allLaunchpads: Self {
         Endpoint(path: "launchpads")
     }
 
     /// Returns a single Launchpads
     /// - Note: https://github.com/r-spacex/SpaceX-API/blob/master/docs/v4/launchpads/one.md
     /// - Parameter id: ID of the Launchpad to get
-    static func launchpad(withId id: String) -> Self {
+    public static func launchpad(withId id: String) -> Self {
         Endpoint(path: "launchpads/\(id)")
     }
 }
@@ -174,14 +174,14 @@ extension Endpoint {
 extension Endpoint {
     /// Returns an array of Payloads
     /// - Note: https://github.com/r-spacex/SpaceX-API/blob/master/docs/v4/payloads/all.md
-    static var allPayloads: Self {
+    public static var allPayloads: Self {
         Endpoint(path: "payloads")
     }
 
     /// Returns a single Payload
     /// - Note: https://github.com/r-spacex/SpaceX-API/blob/master/docs/v4/payloads/one.md
     /// - Parameter id: ID of the Payload to get
-    static func payload(withId id: String) -> Self {
+    public static func payload(withId id: String) -> Self {
         Endpoint(path: "payloads/\(id)")
     }
 }
@@ -190,7 +190,7 @@ extension Endpoint {
 extension Endpoint {
     /// Returns the Roadster info in a single object
     /// - Note: https://github.com/r-spacex/SpaceX-API/blob/master/docs/v4/roadster/get.md
-    static var roadsterInfo: Self {
+    public static var roadsterInfo: Self {
         Endpoint(path: "roadster")
     }
 }
@@ -199,14 +199,14 @@ extension Endpoint {
 extension Endpoint {
     /// Returns an array of Rockets
     /// - Note: https://github.com/r-spacex/SpaceX-API/blob/master/docs/v4/rockets/all.md
-    static var allRockets: Self {
+    public static var allRockets: Self {
         Endpoint(path: "rockets")
     }
 
     /// Returns a single Rocket
     /// - Note: https://github.com/r-spacex/SpaceX-API/blob/master/docs/v4/rockets/one.md
     /// - Parameter id: ID of the Rocket to get
-    static func rocket(withId id: String) -> Self {
+    public static func rocket(withId id: String) -> Self {
         Endpoint(path: "rockets/\(id)")
     }
 }
@@ -215,25 +215,25 @@ extension Endpoint {
 extension Endpoint {
     /// Returns an array of Starlink stats
     /// - Note: https://github.com/r-spacex/SpaceX-API/blob/master/docs/v4/starlink/all.md
-    static var allStarlinkStats: Self {
+    public static var allStarlinkStats: Self {
         Endpoint(path: "starlink")
     }
 
     /// Returns a single Starlink
     /// - Note: https://github.com/r-spacex/SpaceX-API/blob/master/docs/v4/rockets/one.md
     /// - Parameter id: ID of the Starlink to get
-    static func starlink(withId id: String) -> Self {
+    public static func starlink(withId id: String) -> Self {
         Endpoint(path: "starlink/\(id)")
     }
 }
 
 //MARK: - History
 extension Endpoint {
-    static var allHistoricalEvents: Self {
+    public static var allHistoricalEvents: Self {
         Endpoint(path: "history")
     }
 
-    static func historicalEvent(withId id: String) -> Self {
+    public static func historicalEvent(withId id: String) -> Self {
         Endpoint(path: "history/\(id)")
     }
 }
@@ -242,14 +242,14 @@ extension Endpoint {
 extension Endpoint {
     /// Returns an array of Ships
     /// - Note: https://github.com/r-spacex/SpaceX-API/blob/master/docs/v4/ships/all.md
-    static var allShips: Self {
+    public static var allShips: Self {
         Endpoint(path: "ships")
     }
 
     /// Returns a single Ship
     /// - Note: https://github.com/r-spacex/SpaceX-API/blob/master/docs/v4/rockets/one.md
     /// - Parameter id: ID of the Ship to get
-    static func ship(withId id: String) -> Self {
+    public static func ship(withId id: String) -> Self {
         Endpoint(path: "ships/\(id)")
     }
 }

--- a/Sources/SpaceXAPI/Endpoints.swift
+++ b/Sources/SpaceXAPI/Endpoints.swift
@@ -1,11 +1,11 @@
 import Foundation
 
-struct Endpoint {
+public struct Endpoint {
     var path: String
     var queryItems: [URLQueryItem] = []
 }
 
-extension Endpoint {
+public extension Endpoint {
     var url: URL {
         var components = URLComponents()
         components.scheme = "https"

--- a/Sources/SpaceXAPI/JSONDecoder+Extensions.swift
+++ b/Sources/SpaceXAPI/JSONDecoder+Extensions.swift
@@ -1,0 +1,8 @@
+import Foundation
+
+extension JSONDecoder {
+    convenience init(dateDecodingStrategy: JSONDecoder.DateDecodingStrategy) {
+        self.init()
+        self.dateDecodingStrategy = dateDecodingStrategy
+    }
+}

--- a/Sources/SpaceXAPI/NetworkSessionProtocol.swift
+++ b/Sources/SpaceXAPI/NetworkSessionProtocol.swift
@@ -1,0 +1,10 @@
+import Foundation
+
+/// Defines a NetworkSession protocol to allow easier testing
+public protocol NetworkSession {
+    func dataTask(with url: URL,
+                  completionHandler: @escaping (Data?, URLResponse?, Error?) -> Void) -> URLSessionDataTask
+}
+
+/// Conform `URLSession` to `NetworkSession`
+extension URLSession: NetworkSession { }

--- a/Sources/SpaceXAPI/SpaceXAPI+Error.swift
+++ b/Sources/SpaceXAPI/SpaceXAPI+Error.swift
@@ -1,0 +1,22 @@
+import Foundation
+
+public enum SpaceXAPIError: Error {
+    case unknownResponse
+    case serverReturnedCode(Int)
+    case emptyResponse
+}
+
+extension SpaceXAPIError: LocalizedError {
+    public var errorDescription: String? {
+        switch self {
+        case .unknownResponse:
+            return NSLocalizedString("Server returned unknown response", comment: "Server returned unknown response")
+
+        case .serverReturnedCode(let code):
+            return NSLocalizedString("Server returned HTTP code \(code)", comment: "Server returned code")
+
+        case .emptyResponse:
+            return NSLocalizedString("No data returned by the server", comment: "Missing data error")
+        }
+    }
+}

--- a/Sources/SpaceXAPI/SpaceXAPI.swift
+++ b/Sources/SpaceXAPI/SpaceXAPI.swift
@@ -1,15 +1,15 @@
 import Foundation
 
-final public class Api {
+final public class SpaceXAPI {
     private let urlSession: NetworkSession
     private var sessionTask: URLSessionTask?
 
-    public init(urlSession: NetworkSession) {
+    public init(urlSession: NetworkSession = URLSession(configuration: .default)) {
         self.urlSession = urlSession
     }
 }
 
-extension Api {
+extension SpaceXAPI {
     public func get<Model: Codable>(endpoint: Endpoint, completion: @escaping (Result<Model, Error>) -> Void) {
         sessionTask = get(endpoint) { (result) in
             do {
@@ -32,7 +32,7 @@ extension Api {
     }
 }
 
-private extension Api {
+private extension SpaceXAPI {
     private func get(_ endpoint: Endpoint,
                      options: Options? = nil,
                      completion: @escaping (Result<Data, Error>) -> Void) -> URLSessionTask {

--- a/Sources/SpaceXAPI/SpaceXAPI.swift
+++ b/Sources/SpaceXAPI/SpaceXAPI.swift
@@ -62,7 +62,7 @@ private extension SpaceXAPI {
 
             completion(Result.success(data))
         }
-        
+        sessionTask.resume()
         return sessionTask
     }
 

--- a/Sources/SpaceXAPI/SpaceXAPI.swift
+++ b/Sources/SpaceXAPI/SpaceXAPI.swift
@@ -67,14 +67,12 @@ private extension SpaceXAPI {
     }
 
     private func buildURL(for endpoint: Endpoint, using options: Options?) -> URL {
-        let url = endpoint.url.appendingPathComponent(endpoint.path)
+        guard let options = options else { return endpoint.url }
 
-        guard let options = options else { return url }
-
-        var components = URLComponents(url: url, resolvingAgainstBaseURL: false)
+        var components = URLComponents(url: endpoint.url, resolvingAgainstBaseURL: false)
         components?.queryItems = options.queryItems
 
-        return components?.url ?? url
+        return components?.url ?? endpoint.url
     }
 }
 


### PR DESCRIPTION
Adds the API layer, that allows us to make calls to the SpaceX API using the `EndPoint` - example at call site:

```
 let api = SpaceXAPI()

 func loadData() {
        api.get(endpoint: .allLaunches) { (result: Result<[Launch], Error>) in
            do {
                let model = try result.get()
                print(model)
            } catch {
                print("Error: \(error.localizedDescription)")
            }
        }
    }
```